### PR TITLE
Fix Open Blueprint Editor

### DIFF
--- a/hooks/hook_FixOpenBPEditor.cpp
+++ b/hooks/hook_FixOpenBPEditor.cpp
@@ -1,0 +1,15 @@
+//HOOK FixCreateEntityDialog ROffset = 0x004D4010
+#include "../preprocessor/define.h"
+#include "../preprocessor/macro.h"
+
+__asm__
+(
+    ".equ FCED,"QU(FixCreateEntityDialog)"-0x008D4010 \n"
+);
+
+__asm__ volatile
+(   //008D4010 SC_CreateEntityDialog
+    "JMP FCED \n"
+    "NOP \n"
+    ".align 128, 0x0 \n"
+);

--- a/sections/FixOpenBPEditor.cpp
+++ b/sections/FixOpenBPEditor.cpp
@@ -1,0 +1,16 @@
+void FixCreateEntityDialog()
+{
+	__asm__
+    (
+        "MOV EAX,[0x10A6470] \n"
+        "MOV AL,[EAX+0x4D4] \n"
+        "CMP AL,1 \n"
+        "JE L1 \n"
+        "RET \n"
+        "L1: \n"
+        "PUSH EBP \n"
+        "MOV EBP,ESP \n"
+        "AND ESP,0xFFFFFFF8 \n"
+        "JMP 0x008D4016 \n"
+    );
+}

--- a/sections/include/moho.h
+++ b/sections/include/moho.h
@@ -20,7 +20,7 @@ struct luaFuncDescReg
 struct string
 {       // 0x1c bytes
 	void* ptr1;
-	char[0x10] str; // DataPtr or used as memory for 'Short Set Optimization'
+	char str[0x10]; // DataPtr or used as memory for 'Short Set Optimization'
 	uint strLen;
 	uint size; // 0f if SSO, 1f not SSO
 


### PR DESCRIPTION
At the request Philip Fry.
There is a debugging tool in game that allows you to alter unit stats which can be abused to desync games (since your simulation is different from the others if you edit unit stats in game)
abusing this is incredibly annoying and also not easy to prove and there is no reason why it should be possible to use this tool in a game where cheats are disabled.