### PR TITLE
Removed observing after death engine fix

### DIFF
--- a/hooks/hook_ObserverFix.cpp
+++ b/hooks/hook_ObserverFix.cpp
@@ -1,0 +1,7 @@
+//HOOK ObserverFix ROffset = 0x0049671A
+
+__asm__ volatile
+(   //0089671A SetFocusArmy
+    ".byte 0xEB \n"
+    ".align 128, 0x0 \n"
+);

--- a/sections/SimIsReplay.cpp
+++ b/sections/SimIsReplay.cpp
@@ -1,0 +1,14 @@
+void SessionIsReplay()
+{
+	__asm__
+    (
+        "MOV EAX,[0x10A6470] \n"
+        "MOVZX EAX,byte ptr[EAX+0x484] \n"
+        "PUSH EAX \n"
+        "PUSH ESI \n"
+        "CALL 0x0090CF80 \n"     // lua_pushbool
+        "ADD ESP,0x8 \n"
+        "MOV EAX,0x1 \n"
+        "RET \n"
+    );
+}

--- a/sections/ext_sector.cpp
+++ b/sections/ext_sector.cpp
@@ -19,11 +19,19 @@
 funcDefs fd;
 GFT Gft;
 
+luaFuncDescReg SSIRRegDesc = {0x00E45E90,          // Std register func
+                              0x00E4AFBC,          // "SessionIsReplay"
+                              0x00E00D90,          // "<global>"
+                              0x00E4AF84,          // "Return true if the active session is a replay session."
+                              0x010B8AE8,          // Prev reg desc: ArmyGetHandicap
+                              SessionIsReplay,     // Func ptr
+                              0x00000000};         // C++ class vtable ptr
+
 luaFuncDescReg SSFARegDesc = {0x00E45E90,          // Std register func
                               0x00E43408,          // "SetFocusArmy"
                               0x00E00D90,          // "<global>"
                               0x00E451FC,          // "SetFocusArmy(armyIndex or -1)"
-                              0x010B8AE8,          // Prev reg desc: ArmyGetHandicap
+                              &SSIRRegDesc,         // Prev reg desc: SSIRRegDesc
                               SimSetFocusArmy,     // Func ptr
                               0x00000000};         // C++ class vtable ptr
 

--- a/sections/include/global_func_table.h
+++ b/sections/include/global_func_table.h
@@ -36,6 +36,7 @@ void sim_dispatch();
 void Update_Pipeline_Stream();
 void EndGame();
 void SimSetFocusArmy();
+void SessionIsReplay();
 
 class GFT
 {


### PR DESCRIPTION
Modifies user side SetFocusArmy(hook_ObserverFix.cpp).
This patch disables checking the OutOfGame flag in SetFocusArmy. So the death of a player does not make him an observer automatically.

Add Sim SessionIsReplay.

Used with https://github.com/FAForever/fa/pull/2885
Can not be merged separately.