### PR TITLE
Deleting clamp maximum sim rate

### DIFF
--- a/hooks/hook_DelClampMaxSimRate1.cpp
+++ b/hooks/hook_DelClampMaxSimRate1.cpp
@@ -1,0 +1,10 @@
+//HOOK DelClampMaxSimRate ROffset = 0x0015AE56
+
+__asm__ volatile
+(   //0055AE56 CalcMaxSimRate
+    "MOV ESP,EBP \n"
+    "POP EBP \n"
+    "RET \n"
+    "NOP \n"
+    ".align 128,0x0 \n"
+);

--- a/hooks/hook_DelClampMaxSimRate2.cpp
+++ b/hooks/hook_DelClampMaxSimRate2.cpp
@@ -1,0 +1,7 @@
+//HOOK DelClampMaxSimRate ROffset = 0x0048D1FE
+
+__asm__ volatile
+(   //0088D1FE WLD_IncreaseSimRate
+    "CMP EAX,0x32 \n"
+    ".align 128,0x0 \n"
+);

--- a/hooks/hook_DelClampMaxSimRate3.cpp
+++ b/hooks/hook_DelClampMaxSimRate3.cpp
@@ -1,0 +1,11 @@
+//HOOK DelClampMaxSimRate ROffset = 0x0048E1A8
+
+__asm__ volatile
+(   //0088E1A8 WLD_GameSpeed
+    "CMP ESI,0x32 \n"
+    "MOV EDX,ESI \n"
+    "JLE L1 \n"
+    "MOV EDX,0x32 \n"
+    "L1: \n"
+    ".align 128,0x0 \n"
+);

--- a/hooks/hook_DelClampMaxSimRate4.cpp
+++ b/hooks/hook_DelClampMaxSimRate4.cpp
@@ -1,0 +1,7 @@
+//HOOK DelClampMaxSimRate ROffset = 0x0013BE0D
+
+__asm__ volatile
+(   //0053BE0D InitLocalClient
+    ".byte 0x32 \n"
+    ".align 128,0x0 \n"
+);


### PR DESCRIPTION
The limit of the requested game speed via the console commands " WLD_IncreaseSimRate "and" WLD_GameSpeed " was increased to 50.